### PR TITLE
Fix Github remote regex to allow hyphens in repo name

### DIFF
--- a/handkerchief/handkerchief.py
+++ b/handkerchief/handkerchief.py
@@ -39,7 +39,7 @@ from jinja2 import Environment, FileSystemLoader, BaseLoader, PackageLoader
 from os.path import join, realpath, dirname
 from pkg_resources import resource_string
 
-re_mote = re.compile("([a-zA-Z0-9_]*)\s*((git@github.com\:)|(https://github.com/))([a-zA-Z0-9_/]*)\.git\s*\(([a-z]*)\)")
+re_mote = re.compile("([a-zA-Z0-9_]*)\s*((git@github.com\:)|(https://github.com/))([a-zA-Z0-9_\-/]*)\.git\s*\(([a-z]*)\)")
 
 issue_url = 'https://api.github.com/repos/%s/issues?state=%s&filter=all&direction=asc'
 issue_last_re = '<https://api.github.com/repositories/([0-9]*)/issues\?state=%s&filter=all&direction=asc&page=([0-9]*)>; rel="last"'


### PR DESCRIPTION
Github allows repositories to have hyphens in the repository name. This commit updates the Git remote regex to allow hyphens. 

Github actually doesn't allow underscores in the repo name but I have left it in so as not to break if they allow underscores in the future.